### PR TITLE
Bump min numpy version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.4.2"
 description = "A fast python library for calculating the RMS of a NumPy array"
 dependencies = [
     "cffi>=1.0.0",
-    "numpy>=1.21,<2"
+    "numpy>=2,<3"
 ]
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This may seem a bit harsh, but users with numpy 1.* will still have the option of using numpy-rms==0.4.2 which has the same features as numpy-rms 0.5 will have